### PR TITLE
builder: copy files to avoid making etc read-only

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -73,11 +73,15 @@ stdenv.mkDerivation {
       # Hack around broken check for gcc
       touch staging_dir/host/.prereq-build
     ''}
+    ${lib.optionalString (files != null)
+      # copy files to avoid making etc read-only
+      "cp -r --no-preserve=all ${files} files"
+    }
     make image SHELL=${runtimeShell} \
       PROFILE="${profile}" \
       PACKAGES="${lib.concatStringsSep " " packages}" \
       ${lib.optionalString (files != null)
-        ''FILES="${files}"''
+        ''FILES=./files''
       } \
       DISABLED_SERVICES="${lib.concatStringsSep " " disabledServices}" \
       EXTRA_IMAGE_NAME="${extraImageName}"


### PR DESCRIPTION
This caused lines like this to appear in the logs:

    .../sed: couldn't open temporary file .../etc/sed6fJsn9: Permission denied

These errors caused some changes to /etc/group to be missed.

A similar change could probably be made to copy packages rather than link them to get rid of the `copy_file: unable to preserve ownership of ...` messages from opkg, but I doubt that those actually cause issues, and that would only really make sense with #6.