### PR TITLE
Simplify hash generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,11 @@ in
 
 ## Refreshing hashes
 
-Checksums of the `sha256sums` files on downloads.openwrt.org are add
-to this repository for a few recent releases. For updating, modify
-`release` in `generate-hashes.nix`, then run:
+Checksums of the `sha256sums` files on downloads.openwrt.org are added
+to this repository for a few recent releases. To update them, run:
 
 ```bash
 nix-shell -p nixFlakes
-nix run .#generate-hashes
+nix run .#generate-hashes 21.02.3 # for example
 git add hashes/*.nix
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -14,26 +14,9 @@
         "type": "indirect"
       }
     },
-    "openwrt": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1651013664,
-        "narHash": "sha256-efpsYc8KfjIbcD0vdE+VC9tWS471NFAxUB884kJhUEE=",
-        "ref": "master",
-        "rev": "f757a8a09885e3c8bb76371e037b8c0731111980",
-        "revCount": 53988,
-        "type": "git",
-        "url": "https://git.openwrt.org/openwrt/openwrt.git?tag=v21.02.3"
-      },
-      "original": {
-        "type": "git",
-        "url": "https://git.openwrt.org/openwrt/openwrt.git?tag=v21.02.3"
-      }
-    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "openwrt": "openwrt"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,7 @@
 {
   description = "A very basic flake";
 
-  inputs.openwrt = {
-    url = "git+https://git.openwrt.org/openwrt/openwrt.git?tag=v21.02.3";
-    flake = false;
-  };
-
-  outputs = { self, nixpkgs, openwrt }@inputs: {
+  outputs = { self, nixpkgs }@inputs: {
 
     lib.build =
       { pkgs ? nixpkgs.legacyPackages.x86_64-linux

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,6 @@
     # `nix run .#generate-hashes`
     packages.x86_64-linux.generate-hashes = import ./generate-hashes.nix {
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
-      inherit openwrt;
     };
 
     packages.x86_64-linux.example-image = import ./example.nix {


### PR DESCRIPTION
Thanks for merging my other PRs!

This one changes the hash generation to not use the openwrt source flake input; there's a json file with the list of targets on the openwrt downloads site that can be used instead.

My motivation here is to make it easier update the hashes -- currently if the openwrt source input isn't updated to match the version being hashed then some targets/subtargets will go missing -- see for example `realtek` which was split up between 21.02.3 and 22.03.0, so is missing in the current 21.02.3 hashes.

It might be nice to just move this to a plain shell script (with a nix wrapper)?