### PR TITLE
Do not use `/usr/bin/env`, it doesn't exist

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -61,7 +61,10 @@ stdenv.mkDerivation {
     patchShebangs scripts staging_dir/host/bin
     substituteInPlace rules.mk \
       --replace "SHELL:=/usr/bin/env bash" "SHELL:=${runtimeShell}"
-    grep -r usr/bin/env
+    substituteInPlace rules.mk \
+      --replace "/usr/bin/env true" "${coreutils}/bin/true"
+    substituteInPlace rules.mk \
+      --replace "/usr/bin/env false" "${coreutils}/bin/false"
   '';
 
   configurePhase =


### PR DESCRIPTION
This fixes https://github.com/astro/nix-openwrt-imagebuilder/issues/26.

I also removed the `grep -r usr/bin/env` while I was in here. I don't really understand its purpose: it finds and prints all lines containing "usr/bin/env". I thought perhaps the purpose if it was to remind us to always substitute all references to usr/bin/env, but that's definitely not it as it is actually finding stuff (some perl stuff and a few other things that I didn't bother to fix because I didn't run into issues with them). In fact, if it didn't find something, it would exit nonzero and break the build! I could instead tweak this to enforce that there simply are not occurrences of `usr/bin/env` whatsoever, but that would make things a little messier as I'd have to do a bunch of substitutions of dubious value to make it happy.