### PR TITLE
Add missing dependency on `dtc`

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation {
     [
       zlib unzip bzip2
       ncurses which rsync git file getopt wget
-      bash perl python3
+      bash perl python3 dtc
     ] ++
     lib.optional (!lib.versionAtLeast release "21") python2;
 


### PR DESCRIPTION
This fixes https://github.com/astro/nix-openwrt-imagebuilder/issues/28