### PR TITLE
Improve scripts

### DIFF
--- a/.github/workflows/update-hashes.yml
+++ b/.github/workflows/update-hashes.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Update latest release
         shell: bash
         run: |
-          nix eval -f generate-latest-release.nix > latest-release.nix
+          nix run .#generate-latest-release
           git add latest-release.nix
           git commit -m "latest-release: update" || true
       - name: Cache OpenWrt profile information

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,10 @@
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     };
 
+    packages.x86_64-linux.generate-latest-release = import ./generate-latest-release.nix {
+      pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    };
+
     packages.x86_64-linux.cached-profiles = import ./cached-profiles.nix {
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     };

--- a/generate-all-hashes.nix
+++ b/generate-all-hashes.nix
@@ -1,17 +1,22 @@
 { self
 , pkgs
 }:
+pkgs.writeShellApplication {
+  name = "generate-all-hashes";
+  runtimeInputs = [
+    pkgs.curl
+    pkgs.jq
+    self.packages.${pkgs.system}.generate-hashes
+  ];
 
-pkgs.writeShellScriptBin "generate-all-hashes" ''
-  PATH=${pkgs.lib.makeBinPath (with pkgs; [ self.packages.${pkgs.system}.generate-hashes git ])}:$PATH
+  text = ''
+    VERSIONS=$(curl -s https://downloads.openwrt.org/.versions.json)
+    readarray -t RELEASES < <(jq -r '.versions_list[]' <<< "''${VERSIONS}")
+    RELEASES+=("snapshot")
 
-  RELEASES=$(curl -s https://downloads.openwrt.org/releases/ |
-    grep -oP "\"[1-9][0-9\.]+/\"" |
-    sed -e 's/"//g' -e 's/\///' |
-    uniq
-  )
-  for RELEASE in $RELEASES snapshot ; do
-    echo "# Fetching hashes for OpenWrt $RELEASE"
-    generate-hashes $RELEASE
-  done
-''
+    for RELEASE in "''${RELEASES[@]}"; do
+      echo "# Fetching hashes for OpenWrt ''${RELEASE}"
+      generate-hashes "''${RELEASE}"
+    done
+  '';
+}

--- a/generate-latest-release.nix
+++ b/generate-latest-release.nix
@@ -1,22 +1,12 @@
-with builtins;
+{ pkgs }:
+pkgs.writeShellApplication {
+  name = "generate-latest-release";
+  runtimeInputs = [
+    pkgs.curl
+    pkgs.jq
+  ];
 
-head (
-  sort (a: b:
-    if compareVersions a b > 0
-    then true
-    else false
-  ) (
-    concatMap (file:
-      let
-        m = match "(.+)\.nix" file;
-      in
-        if m == null
-        then []
-        else m
-    ) (
-      attrNames (
-        readDir ./hashes
-      )
-    )
-  )
-)
+  text = ''
+    curl -s https://downloads.openwrt.org/.versions.json | jq -c '.stable_version' > latest-release.nix
+  '';
+}


### PR DESCRIPTION
- Use `pkgs.writeShellApplication` instead of `pkgs.writeShellScriptBin` + `PATH`
  `writeShellApplication` also integrates shellcheck into the build process, so the script was changed to follow the recommendations. 
- Turn `generate-latest-release.nix` into a flake package
- Use https://downloads.openwrt.org/.versions.json to get all and latest versions
  - I wasn't able to find what populates this file or how it's created, but [OpenWrt Firmware Selector and Attendedsysupgrade use it](https://github.com/search?q=org%3Aopenwrt+versions.json&type=code), so I assume it's safe and up-to-date. Having a JSON makes things much simpler and easier to work with.