### PR TITLE
Use flake-parts

### DIFF
--- a/example-x86-64.nix
+++ b/example-x86-64.nix
@@ -1,9 +1,9 @@
 { pkgs ? import <nixpkgs> {}
-, profiles ? import ./profiles.nix { inherit pkgs; }
 , build ? import ./builder.nix
 }:
 
 build {
+  inherit pkgs;
   target = "x86";
   variant = "64";
   profile = "generic";

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1701253981,
@@ -16,9 +34,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1680978846,
+        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "x86_64-linux",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1730504689,
@@ -32,18 +34,6 @@
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     systems.url = "github:nix-systems/x86_64-linux";
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
   };
 
   outputs = inputs@{ flake-parts, systems, ... }: flake-parts.lib.mkFlake { inherit inputs; } ({ config, self, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -1,83 +1,63 @@
 {
   description = "Build OpenWRT images in Nix derivations";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }: {
-
-    lib.build =
-      { pkgs ? nixpkgs.legacyPackages.x86_64-linux
-      , ...
-      }@args:
-      import ./builder.nix (args // {
-        inherit pkgs;
-      });
-
-    lib.profiles =
-      { pkgs ? nixpkgs.legacyPackages.x86_64-linux
-      , release ? import ./latest-release.nix
-      , ...
-      }@args:
-      import ./profiles.nix (args // {
-        inherit pkgs release;
-      });
-
-    packages.x86_64-linux.profiles-list = import ./profiles-list.nix {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    };
-
-    # `nix run .#generate-hashes`
-    packages.x86_64-linux.generate-hashes = import ./generate-hashes.nix {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    };
-
-    packages.x86_64-linux.generate-all-hashes = import ./generate-all-hashes.nix {
-      inherit self;
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    };
-
-    packages.x86_64-linux.generate-latest-release = import ./generate-latest-release.nix {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    };
-
-    packages.x86_64-linux.cached-profiles = import ./cached-profiles.nix {
-      pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    };
-
-    packages.x86_64-linux.example-image =
-      let
-        image = import ./example.nix rec {
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          profiles = self.lib.profiles {
-            inherit pkgs;
-          };
-          inherit (self.lib) build;
-        };
-      in
-      # Wrap `image` once to avoid `nix flake show` breaking on IFD
-      nixpkgs.legacyPackages.x86_64-linux.runCommand "example-image" {} ''
-        ln -s ${image} $out
-      '';
-
-    packages.x86_64-linux.example-x86-64-image =
-      let
-        image = import ./example-x86-64.nix rec {
-          pkgs = nixpkgs.legacyPackages.x86_64-linux;
-          profiles = self.lib.profiles {
-            inherit pkgs;
-          };
-          inherit (self.lib) build;
-        };
-      in
-      # Wrap `image` once to avoid `nix flake show` breaking on IFD
-      nixpkgs.legacyPackages.x86_64-linux.runCommand "example-x86-64-image" {} ''
-        ln -s ${image} $out
-      '';
-
-    checks = self.packages;
-
-    hydraJobs = {
-      inherit (self.packages.x86_64-linux) example-image;
-    };
+    systems.url = "github:nix-systems/x86_64-linux";
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
+
+  outputs = inputs@{ flake-parts, systems, ... }: flake-parts.lib.mkFlake { inherit inputs; } ({ config, self, ... }: {
+    systems = import systems;
+
+    perSystem = { pkgs, ... }: rec {
+      packages = rec {
+        profiles-list = pkgs.callPackage ./profiles-list.nix { };
+        generate-hashes = pkgs.callPackage ./generate-hashes.nix { };
+        generate-all-hashes = pkgs.callPackage ./generate-all-hashes.nix { inherit generate-hashes; };
+        cached-profiles = pkgs.callPackage ./cached-profiles.nix { };
+
+        example-image =
+          let
+            image = import ./example.nix rec {
+              inherit pkgs;
+              profiles = self.lib.profiles {
+                inherit pkgs;
+              };
+              inherit (self.lib) build;
+            };
+          in
+          # Wrap `image` once to avoid `nix flake show` breaking on IFD
+          pkgs.runCommand "example-image" { } ''
+            ln -s ${image} $out
+          '';
+
+        example-x86-64-image =
+          let
+            image = import ./example-x86-64.nix {
+              inherit pkgs;
+              inherit (self.lib) build;
+            };
+          in
+          # Wrap `image` once to avoid `nix flake show` breaking on IFD
+          pkgs.runCommand "example-x86-64-image" { } ''
+            ln -s ${image} $out
+          '';
+      };
+
+      checks = packages;
+    };
+
+    flake = {
+      lib = {
+        build = import ./builder.nix;
+
+        profiles = import ./profiles.nix;
+      };
+
+      hydraJobs = builtins.mapAttrs (system: _: { inherit (self.packages.${system}) example-image; }) config.allSystems;
+    };
+  });
+
 }

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
         profiles = import ./profiles.nix;
       };
 
-      hydraJobs = builtins.mapAttrs (system: _: { inherit (self.packages.${system}) example-image; }) config.allSystems;
+      hydraJobs = { inherit (self.packages.x86_64-linux) example-image; };
     };
   });
 

--- a/generate-all-hashes.nix
+++ b/generate-all-hashes.nix
@@ -1,12 +1,12 @@
-{ self
-, pkgs
+{ pkgs,
+  generate-hashes
 }:
 pkgs.writeShellApplication {
   name = "generate-all-hashes";
   runtimeInputs = [
     pkgs.curl
     pkgs.jq
-    self.packages.${pkgs.system}.generate-hashes
+    generate-hashes
   ];
 
   text = ''


### PR DESCRIPTION
This PR reworks `flake.nix` and introduces [`flake-parts`](https://flake.parts/) library to do that. It provides abstraction from the `${system}` and automatic arguments like `pkgs` and `lib`, simplifying the code. It also utilizes the module system to provide type safety and the possibility to split the configuration easily in the future. 

This is a more opinionated change compared to my previous PRs, so let me know what you think.