### PR TITLE
Add support for separate Kmods

### DIFF
--- a/generate-hashes.nix
+++ b/generate-hashes.nix
@@ -1,60 +1,89 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.writeShellApplication {
+  name = "generate-hashes";
+  runtimeInputs = [
+    pkgs.curl
+    pkgs.jq
+    pkgs.nix
+  ];
 
-pkgs.writeShellScriptBin "generate-hashes" ''
-PATH=${pkgs.lib.makeBinPath (with pkgs; [ jq curl nix ])}:$PATH
+  text = ''
+    RELEASE="''${1:-${import ./latest-release.nix}}"
+    FEEDS="base luci packages routing telephony"
 
-RELEASE="${import ./latest-release.nix}"
-FEEDS="base luci packages routing telephony"
+    UPSTREAM_URL=https://downloads.openwrt.org
+    RELEASE_URL="''${UPSTREAM_URL}/releases/''${RELEASE}"
 
-if [ $# -gt 0 ]; then
-  RELEASE=$1
-fi
-
-UPSTREAM_URL=https://downloads.openwrt.org
-RELEASE_URL=$UPSTREAM_URL/releases/$RELEASE
-
-if [ $RELEASE == "snapshot" ]; then
-  RELEASE_URL=$UPSTREAM_URL/snapshots;
-fi
-
-declare -A arches_fetched
-
-hash() {
-  TARGET=$1
-  VARIANT=$2
-  echo "- $TARGET/$VARIANT" >&2
-  BASEURL=$RELEASE_URL/targets/$TARGET/$VARIANT
-  SUM=$(nix store prefetch-file --json $BASEURL/sha256sums 2>/dev/null | jq -r .hash)
-  if [ -n "$SUM" ]; then
-    echo "  targets.\"$TARGET\".\"$VARIANT\".sha256 = \"$SUM\";"
-    ARCH=$(curl -s $BASEURL/profiles.json | jq -r .arch_packages)
-    [ $? -ne 0 ] && echo "failed to fetch or parse $BASEURL/profiles.json" > /dev/stderr
-    if [ -n "$ARCH" ]; then
-      echo "  targets.\"$TARGET\".\"$VARIANT\".packagesArch = \"$ARCH\";"
-      if [ -z "''${arches_fetched[$ARCH]}" ]; then
-        for FEED in $FEEDS; do
-          echo "  - $FEED" >&2
-          SUM=$(nix store prefetch-file --json $RELEASE_URL/packages/$ARCH/$FEED/Packages 2>/dev/null | jq -r .hash)
-          echo "  packages.\"$ARCH\".\"$FEED\".sha256 = \"$SUM\";"
-        done
-        arches_fetched[$ARCH]="done"
-      fi
+    if [ "''${RELEASE}" == "snapshot" ]; then
+      RELEASE_URL="''${UPSTREAM_URL}/snapshots";
     fi
-  fi
+
+    KMODS_SEPARATE=false
+    if [[ "''${RELEASE}" == "snapshot" || "''${RELEASE}" == 24* ]]; then
+      KMODS_SEPARATE=true
+    fi
+
+    declare -g -A arches_fetched
+
+    hash() {
+      TARGET=$1
+      VARIANT=$2
+
+      echo "- ''${TARGET}/''${VARIANT}" >&2
+
+      BASE_URL="''${RELEASE_URL}/targets/''${TARGET}/''${VARIANT}"
+
+      SUMS_HASH=$(nix store prefetch-file --json "''${BASE_URL}/sha256sums" 2>/dev/null | jq -r .hash)
+      if [ -n "$SUMS_HASH" ]; then
+        echo "  targets.\"''${TARGET}\".\"''${VARIANT}\".sha256 = \"''${SUMS_HASH}\";"
+
+        PROFILES=$(curl --silent --fail "''${BASE_URL}/profiles.json" || true)
+        if [ -z "$PROFILES" ]; then
+          echo "Failed to fetch ''${BASE_URL}/profiles.json" >&2
+        else
+          if ''${KMODS_SEPARATE}; then
+            KERNEL_RELEASE=$(jq -r '.linux_kernel.release' <<< "''${PROFILES}")
+            KERNEL_VERSION=$(jq -r '.linux_kernel.version' <<< "''${PROFILES}")
+            KERNEL_VERMAGIC=$(jq -r '.linux_kernel.vermagic' <<< "''${PROFILES}")
+
+            KMODS_TARGET="''${KERNEL_VERSION}-''${KERNEL_RELEASE}-''${KERNEL_VERMAGIC}"
+
+            echo "  - kmods" >&2
+            KMODS_HASH=$(nix store prefetch-file --json "''${BASE_URL}/kmods/''${KMODS_TARGET}/Packages" 2>/dev/null | jq -r .hash)
+            echo "  kmods.\"''${TARGET}\".\"''${VARIANT}\".\"''${KMODS_TARGET}\".sha256 = \"''${KMODS_HASH}\";"
+          fi
+
+          ARCH=$(jq -r '.arch_packages' <<< "''${PROFILES}")
+          if [ -n "$ARCH" ]; then
+            echo "  targets.\"''${TARGET}\".\"''${VARIANT}\".packagesArch = \"''${ARCH}\";"
+
+            if [ -z "''${arches_fetched[$ARCH]:-}" ]; then
+              for FEED in ''${FEEDS}; do
+                echo "  - ''${FEED}" >&2
+                PACKAGES_HASH=$(nix store prefetch-file --json "''${RELEASE_URL}/packages/''${ARCH}/''${FEED}/Packages" 2>/dev/null | jq -r .hash)
+                echo "  packages.\"''${ARCH}\".\"''${FEED}\".sha256 = \"''${PACKAGES_HASH}\";"
+              done
+              
+              arches_fetched[$ARCH]="done"
+            fi
+          fi
+        fi
+      fi
+    }
+
+    mkdir -p hashes
+
+    (
+      echo "{"
+      curl -s "''${RELEASE_URL}/targets/?json-targets" | jq -r .[] | while IFS=/ read -r TARGET VARIANT; do
+        hash "''${TARGET}" "''${VARIANT}"
+      done
+      echo "}"
+    ) > "hashes/''${RELEASE}.nix"
+
+    if [ "$(stat -c %s "hashes/''${RELEASE}.nix")" -le 10 ] ; then
+      # Too small, no entries, discard.
+      rm -v "hashes/''${RELEASE}.nix"
+    fi
+  '';
 }
-
-mkdir -p hashes
-
-(
-  echo "{"
-  curl -s $RELEASE_URL/targets/?json-targets | jq -r .[] | while IFS=/ read TARGET VARIANT; do
-    hash $TARGET $VARIANT
-  done
-  echo "}"
-) > hashes/$RELEASE.nix
-
-if [ $(stat -c %s hashes/$RELEASE.nix) -le 10 ] ; then
-  # Too small, no entries, discard.
-  rm -v hashes/$RELEASE.nix
-fi
-''


### PR DESCRIPTION
As I explained in #47, builds on https://downloads.openwrt.org for OpenWRT >= 24 no longer have `kmod-*` packages in the `packages` feed. Instead, it's located at `https://downloads.openwrt.org/snapshots/targets/{TARGET}/{SUBTARGET}/kmods/{KMOD_TARGET}`. 
So we need to adjust the script to obtain new hashes in `generate-hashes.nix` and inject them as a "virtual" feed in the `files.nix`. The `generate-hashes` function was also refactored and now uses `writeShellApplication`.

The new hashes structure can be tested with `nix run .#generate-hashes "24.10.0-rc2"`. The file should look like this:
```nix
  targets."kirkwood"."generic".sha256 = "sha256-hh4oZv4L/kBIx60DjJMvdW+gE5sE6oA0tP8N4kuztr0=";
  kmods."kirkwood"."generic"."6.6.63-1-316f788de839e861f7fea23702a4776b".sha256 = "sha256-MM51lpdRO9rWYhCjywV4O5qOCtu8IdirYH/KDngLn08=";
  targets."kirkwood"."generic".packagesArch = "arm_xscale";
  packages."arm_xscale"."base".sha256 = "sha256-BOC8iFjkXHXBt7RhDXeLEAITqTiRkIYg9y0eIFtg7LU=";
  packages."arm_xscale"."luci".sha256 = "sha256-fKzykHlVLTTsdEqse5D4jPvbupSe72sWME3DDV2wCPA=";
  packages."arm_xscale"."packages".sha256 = "sha256-Qw6JXQFWjeuf2RuvQj3GKfhHKEumQ2o2LW4iCXLtSZw=";
  packages."arm_xscale"."routing".sha256 = "sha256-F3rZa9XfRWrNAYQbBrLQ6cx3MQzbCoyKTpe+dnNcTkM=";
  packages."arm_xscale"."telephony".sha256 = "sha256-wmGZoc+a87QzlJiIsh5q56FeR3+A6jxwKkatskpbr6g=";
```

This is a relatively simple fix as OpenWRT 24.10 still uses `opkg`.