### PR TITLE
Fix hash generation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "lastModified": 1734119587,
+        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
         "type": "github"
       },
       "original": {

--- a/generate-hashes.nix
+++ b/generate-hashes.nix
@@ -7,6 +7,8 @@ pkgs.writeShellApplication {
     pkgs.nix
   ];
 
+  bashOptions = [ "nounset" "pipefail" ];
+
   text = ''
     RELEASE="''${1:-${import ./latest-release.nix}}"
     FEEDS="base luci packages routing telephony"


### PR DESCRIPTION
Since `generate-hashes` migrated to `writeShellApplication`, the hash generation jobs failed. Mainly because `snapshot` branch doesn't have `Packages` files anymore.

`writeShellApplication` sets these flags for the script:
```shell
set -o errexit
set -o nounset
set -o pipefail
```

And since https://github.com/NixOS/nixpkgs/pull/280592 they are configurable. So we can remove `errexit`, but because this repo's `nixpkgs` was quite old ([more than a year](https://github.com/NixOS/nixpkgs/commit/e92039b55bcd58469325ded85d4f58dd5a4eaf58)) I had to update it first.

**Disclaimer**: this doesn't fix the builds, only makes the script not fail on errors, allowing to update hashes for OpenWRT =<24