### PR TITLE
generate-all-hashes: fetch all versions in parallel

### DIFF
--- a/generate-all-hashes.nix
+++ b/generate-all-hashes.nix
@@ -16,7 +16,9 @@ pkgs.writeShellApplication {
 
     for RELEASE in "''${RELEASES[@]}"; do
       echo "# Fetching hashes for OpenWrt ''${RELEASE}"
-      generate-hashes "''${RELEASE}"
+      generate-hashes "''${RELEASE}" &
     done
+
+    wait
   '';
 }

--- a/generate-hashes.nix
+++ b/generate-hashes.nix
@@ -31,8 +31,6 @@ pkgs.writeShellApplication {
       TARGET=$1
       VARIANT=$2
 
-      echo "- ''${TARGET}/''${VARIANT}" >&2
-
       BASE_URL="''${RELEASE_URL}/targets/''${TARGET}/''${VARIANT}"
 
       SUMS_HASH=$(nix store prefetch-file --json "''${BASE_URL}/sha256sums" 2>/dev/null | jq -r .hash)
@@ -50,7 +48,6 @@ pkgs.writeShellApplication {
 
             KMODS_TARGET="''${KERNEL_VERSION}-''${KERNEL_RELEASE}-''${KERNEL_VERMAGIC}"
 
-            echo "  - kmods" >&2
             KMODS_HASH=$(nix store prefetch-file --json "''${BASE_URL}/kmods/''${KMODS_TARGET}/Packages" 2>/dev/null | jq -r .hash)
             echo "  kmods.\"''${TARGET}\".\"''${VARIANT}\".\"''${KMODS_TARGET}\".sha256 = \"''${KMODS_HASH}\";"
           fi
@@ -61,7 +58,6 @@ pkgs.writeShellApplication {
 
             if [ -z "''${arches_fetched[$ARCH]:-}" ]; then
               for FEED in ''${FEEDS}; do
-                echo "  - ''${FEED}" >&2
                 PACKAGES_HASH=$(nix store prefetch-file --json "''${RELEASE_URL}/packages/''${ARCH}/''${FEED}/Packages" 2>/dev/null | jq -r .hash)
                 echo "  packages.\"''${ARCH}\".\"''${FEED}\".sha256 = \"''${PACKAGES_HASH}\";"
               done


### PR DESCRIPTION
Example run:
https://github.com/MarcelCoding/nix-openwrt-imagebuilder/actions/runs/14803939847/job/41568704353