### PR TITLE
Add an `extraPackages` parameter for easier custom packages

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -23,8 +23,13 @@
   ).packages.${packagesArch}
 # Attrset where key is kmodsTarget and value is checksum of `Packages` file. Required for OpenWRT >=24
 , kmodsSha256 ? {}
-# Extra OpenWRT packages (can be prefixed with "-")
+# Extra OpenWRT package names (can be prefixed with "-")
 , packages ? []
+# Allows specifying additional packages that are not packaged by openwrt.
+# Note: unlike `packages`, this is not a list of names, it's an attrset of
+# package details. See `parsePackages` in `files.nix` for details on the
+# format.
+, extraPackages ? {}
 # Include extra files
 , files ? null
 # Which services in /etc/init.d/ should be disabled
@@ -46,7 +51,7 @@ let
   );
 
   inherit (import ./files.nix {
-    inherit pkgs release target variant sha256 feedsSha256 packagesArch;
+    inherit pkgs release target variant sha256 feedsSha256 packagesArch extraPackages;
     kmodsSha256 = maybeKmodsSha256;
   }) variantFiles profiles expandDeps corePackages packagesByFeed allPackages;
 
@@ -72,6 +77,7 @@ let
     "files"
     "disabledServices"
     "extraImageName"
+    "extraPackages"
     "rootFsPartSize"
   ];
 in

--- a/files.nix
+++ b/files.nix
@@ -12,6 +12,8 @@
 , kmodsSha256 ? {}
 # Manually specify packages' arch for OpenWRT<19 releases without profiles.json
 , packagesArch ? null
+# Allows specifying additional packages that are not packaged by openwrt.
+, extraPackages ? {}
 }:
 let
   inherit (pkgs) lib fetchurl;
@@ -183,8 +185,7 @@ let
       kernel = dummyPackage;
     };
 
-  # all packages, including dummy and virtual
-  allPackages = addVirtual (realPackages // dummyPackages);
+  allPackages = addVirtual (realPackages // dummyPackages // extraPackages);
 
   # remove package names starting with '-' from deps
   #


### PR DESCRIPTION
refs: https://github.com/astro/nix-openwrt-imagebuilder/issues/38

For example, here's how I plan to use this to override a package with a fork I maintain:

```nix
openwrt-imagebuilder.lib.build (
  profile
  // {
    # Override `wifi-presence` with my fork. See
    # <https://github.com/awilliams/wifi-presence/pull/31> for details.
    # See
    # ~/sync/jfly/notes/2025-08-04-building-wifi-presence-for-openwrt.md
    # for details on how to rebuild this.
    extraPackages.wifi-presence = {
      depends = [ "libc" ];
      provides = null;
      type = "real";

      file = pkgs.fetchurl {
        url = "https://github.com/jfly/wifi-presence/releases/download/v0.3.0-with-read-workaround/wifi-presence_issue-30-workaround-r1_aarch64_cortex-a53.ipk";
        hash = "";
      };
      filename = "wifi-presence_issue-30-workaround-r1_aarch64_cortex-a53.ipk";
    };
```