### PR TITLE
Fix builder

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -4,7 +4,7 @@
 , stdenv ? pkgs.stdenv
 , fetchurl ? pkgs.fetchurl
 , writeScript ? pkgs.writeScript
-, callPackages2nix ? pkgs.callPackages2nix
+, callPackages2nix ? pkgs.callPackage ./call-packages2nix.nix { }
 # OpenWRT release
 , release ? openwrtLib.latestRelease
 # OpenWRT target

--- a/call-packages2nix.nix
+++ b/call-packages2nix.nix
@@ -1,6 +1,6 @@
-{ lib
+{ callPackage
 , runCommand
-, packages2nix
+, packages2nix ? callPackage ./packages2nix.nix { }
 }:
 
 { mode, packages, sha256sums, prefix }: let

--- a/packages2nix.nix
+++ b/packages2nix.nix
@@ -2,7 +2,7 @@
 , writeShellApplication
 , jq
 , apk-tools
-, jqlibdir
+, jqlibdir ? ./.
 }:
 
 writeShellApplication {

--- a/profiles.nix
+++ b/profiles.nix
@@ -15,9 +15,7 @@ let
     if pkgs ? packages2nix && pkgs ? callPackages2nix
     then pkgs
     else pkgs.extend (final: prev: {
-      packages2nix = final.callPackage ./packages2nix.nix {
-        jqlibdir = ./.;
-      };
+      packages2nix = final.callPackage ./packages2nix.nix { };
       callPackages2nix = final.callPackage ./call-packages2nix.nix { };
     });
 


### PR DESCRIPTION
```
 ➜ command nix build .#openwrt -L --show-trace
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'openwrt-24.10.5-ipq40xx-generic-avm_fritzbox-7530'
         whose name attribute is located at «github:SuperSandro2000/nixpkgs/881383120fd3f2b93c0535b7ca94eca002690114?narHash=sha256-WUAxCrJ5Kb5RNpOjglLbEVHZTqnoL5P0AUWPdkCkA1Y%3D»/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'configurePhase' of derivation 'openwrt-24.10.5-ipq40xx-generic-avm_fritzbox-7530'
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/builder.nix:95:3:
           94|
           95|   configurePhase =
             |   ^
           96|     let

       … while calling the 'getAttr' builtin
         at «nix-internal»/derivation-internal.nix:50:17:
           49|     value = commonAttrs // {
           50|       outPath = builtins.getAttr outputName strict;
             |                 ^
           51|       drvPath = strict.drvPath;

       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'install-openwrt-packages'
         whose name attribute is located at «github:SuperSandro2000/nixpkgs/881383120fd3f2b93c0535b7ca94eca002690114?narHash=sha256-WUAxCrJ5Kb5RNpOjglLbEVHZTqnoL5P0AUWPdkCkA1Y%3D»/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'text' of derivation 'install-openwrt-packages'
         at «github:SuperSandro2000/nixpkgs/881383120fd3f2b93c0535b7ca94eca002690114?narHash=sha256-WUAxCrJ5Kb5RNpOjglLbEVHZTqnoL5P0AUWPdkCkA1Y%3D»/pkgs/build-support/trivial-builders/default.nix:129:13:
          128|           inherit
          129|             text
             |             ^
          130|             executable

       … from call site
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/builder.nix:112:9:
          111|       installPackages = writeScript "install-openwrt-packages" (
          112|         lib.concatMapStrings (pname:
             |         ^
          113|           let

       … while calling 'concatMapStrings'
         at «github:SuperSandro2000/nixpkgs/881383120fd3f2b93c0535b7ca94eca002690114?narHash=sha256-WUAxCrJ5Kb5RNpOjglLbEVHZTqnoL5P0AUWPdkCkA1Y%3D»/lib/strings.nix:124:25:
          123|   */
          124|   concatMapStrings = f: list: concatStrings (map f list);
             |                         ^
          125|

       … while calling the 'concatStringsSep' builtin
         at «github:SuperSandro2000/nixpkgs/881383120fd3f2b93c0535b7ca94eca002690114?narHash=sha256-WUAxCrJ5Kb5RNpOjglLbEVHZTqnoL5P0AUWPdkCkA1Y%3D»/lib/strings.nix:124:31:
          123|   */
          124|   concatMapStrings = f: list: concatStrings (map f list);
             |                               ^
          125|

       … while calling the 'map' builtin
         at «github:SuperSandro2000/nixpkgs/881383120fd3f2b93c0535b7ca94eca002690114?narHash=sha256-WUAxCrJ5Kb5RNpOjglLbEVHZTqnoL5P0AUWPdkCkA1Y%3D»/lib/strings.nix:124:46:
          123|   */
          124|   concatMapStrings = f: list: concatStrings (map f list);
             |                                              ^
          125|

       … from call site
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/builder.nix:47:25:
           46|     ++ packages;
           47|   allRequiredPackages = expandDeps allPackages requiredPackages;
             |                         ^
           48|

       … while calling anonymous lambda
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:130:5:
          129|     in
          130|     deps: builtins.attrNames (builtins.foldl' addDep { } (applyMinusDeps deps));
             |     ^
          131|

       … while calling the 'attrNames' builtin
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:130:11:
          129|     in
          130|     deps: builtins.attrNames (builtins.foldl' addDep { } (applyMinusDeps deps));
             |           ^
          131|

       … while calling the 'foldl'' builtin
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:130:31:
          129|     in
          130|     deps: builtins.attrNames (builtins.foldl' addDep { } (applyMinusDeps deps));
             |                               ^
          131|

       … while calling 'addDep'
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:119:30:
          118|     let
          119|       addDep = current_deps: new_dep:
             |                              ^
          120|         if builtins.hasAttr new_dep current_deps

       … while calling the 'foldl'' builtin
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:128:11:
          127|           in
          128|           builtins.foldl' addDep with_new_dep deps;
             |           ^
          129|     in

       … while evaluating the attribute 'allPackages'
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:134:11:
          133| in {
          134|   inherit allPackages corePackages packagesByFeed expandDeps;
             |           ^
          135| }

       … from call site
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:97:17:
           96|
           97|   allPackages = addVirtual (realPackages // dummyPackages // extraPackages);
             |                 ^
           98|

       … while calling 'addVirtual'
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:58:16:
           57|   # providers will be downloaded
           58|   addVirtual = packages:
             |                ^
           59|     builtins.foldl'

       … while calling the 'foldl'' builtin
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:59:5:
           58|   addVirtual = packages:
           59|     builtins.foldl'
             |     ^
           60|       (packages: pn:

       … while calling the 'attrNames' builtin
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:85:8:
           84|       packages
           85|       (builtins.attrNames packages);
             |        ^
           86|

       … in the left operand of the update (//) operator
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:97:29:
           96|
           97|   allPackages = addVirtual (realPackages // dummyPackages // extraPackages);
             |                             ^
           98|

       … in the right operand of the update (//) operator
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:51:8:
           50|     (builtins.foldl' (a: b: a // b) { } (builtins.attrValues packagesByFeed))
           51|     // corePackages;
             |        ^
           52|

       … from call site
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:47:18:
           46|
           47|   corePackages = loadPackages cache.corePackages;
             |                  ^
           48|

       … while calling 'loadPackages'
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:11:18:
           10| let
           11|   loadPackages = { baseUrl, sourceInfo, packages ? null, sha256sums, prefix, ... }: let
             |                  ^
           12|     packages' = if packages != null

       … while calling the 'mapAttrs' builtin
         at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/files.nix:21:5:
           20|   in
           21|     loadPackages' baseUrl packages';
             |     ^
           22|

       error: attribute 'callPackages2nix' missing
       at «github:astro/nix-openwrt-imagebuilder/004828e29d2190336af02014625958344cc87f14?narHash=sha256-TMPXGUgHE61CO/HC73g6wdfHw/E3HQ8/3m48SyxF6sc%3D»/builder.nix:7:22:
            6| , writeScript ? pkgs.writeScript
            7| , callPackages2nix ? pkgs.callPackages2nix
             |                      ^
            8| # OpenWRT release
```