### PR TITLE
builder: fix build for genexis pulse ex400

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -212,7 +212,7 @@ stdenv.mkDerivation ({
 
   postInstall = ''
     shopt -s nullglob
-    files=($out/openwrt-*-squashfs-sysupgrade.* $out/openwrt-*.img.gz)
+    files=($out/openwrt-*-sysupgrade.* $out/openwrt-*.img.gz)
     if ! (( ''${#files[@]} )); then
       echo "Build produced no bin file, see above for details"
       ls -l $out/


### PR DESCRIPTION
The binary there is somehow named:
  openwrt-24.10.5-ramips-mt7621-genexis_pulse-ex400-sysupgrade.bin