### PR TITLE
builder: Remove cachePath from derivation attrs

### DIFF
--- a/builder.nix
+++ b/builder.nix
@@ -53,6 +53,7 @@ let
     "stdenv"
     "fetchurl"
     "writeScript"
+    "cachePath"
   ];
   configArgs = [
     "release"


### PR DESCRIPTION
cachePath is only needed for evaluating, not building.

Adding it as derivation attr will let Nix make another copy to nix store.

`diff -u <(nix derivation show --pretty /nix/store/<before>) <(nix derivation show --pretty /nix/store/<after>)`:

``` diff
 {
-  "/nix/store/<before>.drv": {
+  "/nix/store/<after>.drv": {
     "args": [
       "-e",
       "/nix/store/l622p70vy8k5sh7y5wizi5f2mic6ynpg-source-stdenv.sh",
@@ -11,7 +11,6 @@
       "builder": "/nix/store/fwr62xmh06l8y8zfgc5m18pfap9b8az0-bash-5.3p3/bin/bash",
-      "cachePath": "/nix/store/1xgh54mrv3hrchmpcgif6557cyxmqqy4-25.12.0",
       "cmakeFlags": "",
...
     "inputSrcs": [
-      "/nix/store/1xgh54mrv3hrchmpcgif6557cyxmqqy4-25.12.0",
       "/nix/store/gg1x1kqwbh57p2kcb8ac6bb6ja77syjb-mipsel_24kc-routing-packages.adb",
...
```

```
$ ls /nix/store/1xgh54mrv3hrchmpcgif6557cyxmqqy4-25.12.0
default.nix  packages  targets
```