### PR TITLE
Fix OpenWrt 25 not installing some virtual packages

### DIFF
--- a/files.nix
+++ b/files.nix
@@ -63,21 +63,20 @@ let
         in
         if p.provides or [] != []
         then
-          let
-            vp = {
-              type = "virtual";
-              depends = [ ];
-            };
-          in
-            builtins.foldl' (packages: provide:
-              if ! packages ? ${provide}
-              then
-                packages // {
-                  ${provide} = vp // { depends = vp.depends ++ [ pn ]; };
-                }
-              else
-                packages
-            ) packages p.provides
+          builtins.foldl' (packages: provide:
+            let
+              vp = packages.${provide} or {
+                type = "virtual";
+                depends = [ ];
+              };
+            in
+            if vp.type == "virtual" then
+              packages // {
+                ${provide} = vp // { depends = vp.depends ++ [ pn ]; };
+              }
+            else
+              packages
+          ) packages p.provides
         else
           packages
       )


### PR DESCRIPTION
For example, `ddns-scripts` depends on virtual package `ip`, but neither `ip-full` nor `ip-tiny` get installed:

```
$ cat result/*.manifest | grep '^ip' # no output
$ nix log result/ | grep ip-
( 42/149) Installing ip-tiny (6.18.0-r2)
ERROR: ip-tiny-6.18.0-r2: package mentioned in index not found (try 'apk update')
```

The problem is only 1 real package(ip-full) is added to `packages/` dir, OpenWrt 24 works fine with this, but OpenWrt 25 does not after switching to `apk`.

This commit fixes the virtual package `depends` calculation, before allPackages.ip is:

```
{
  depends = [ "ip-full" ];
  type = "virtual";
}
```

After:
```
{
  depends = [ "ip-full" "ip-tiny" ];
  type = "virtual";
}
```