### PR TITLE
Fix uncatchable error when `identifyProfile` finds more than one matching profile

### DIFF
--- a/profiles.nix
+++ b/profiles.nix
@@ -58,8 +58,8 @@ in rec {
       else if matches == []
       then throw "No match for OpenWRT profile ${profile}"
       else builtins.trace ''
-        ${builtins.length matches} matches for OpenWRT profile ${profile}
-        ${lib.concatMapStrings ({ target, variant }: ''
+        ${toString (builtins.length matches)} matches for OpenWRT profile ${profile}
+        ${lib.concatMapStrings ({ target, variant, ... }: ''
         - ${target}/${variant}
         '') matches}
         Using first.


### PR DESCRIPTION
By: 

1. Explicitly stringifying the integer representing the number of matching profiles that is used in the diagnostic message, and
2. Allowing arbitrary named arguments when mapping over the list of profile attrsets.

Thanks in advance for your consideration!